### PR TITLE
Fix to list all repos (limit -> pagelen)

### DIFF
--- a/main.py
+++ b/main.py
@@ -96,7 +96,7 @@ def createGiteaOrganization(projectName, fullName, description):
 
 def getReposBB():
     """ Get all bitbucket repos and it's parameters: clone url, repo name, project name, description."""
-    BitbucketAPIurl = f"{props.BitbucketURL}/2.0/repositories/{props.BitbucketWorkspace}?limit=1000"
+    BitbucketAPIurl = f"{props.BitbucketURL}/2.0/repositories/{props.BitbucketWorkspace}?pagelen=1000"
     try:
         response = requests.get(BitbucketAPIurl, headers=headersBB)
         response.raise_for_status()


### PR DESCRIPTION
Tried to use this, migrated first 10 repos only, examined response JSON, it was paging responses, by default with page size of 10.

Updated URL with arg to modify page size.